### PR TITLE
All pages snap to the top of the page on change

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,5 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
+import {useEffect} from "react";
 import Home from "./pages/Home";
 import AboutUs from "./pages/AboutUs";
 import ReusableProgram from "./pages/ReusableProgram";
@@ -10,9 +11,21 @@ import Admin from "./pages/Admin";
 import Partners from "./pages/Partners";
 import Approvals from "./pages/Approvals";
 
+function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}
+
+
 export default function App() {
     return (
         <BrowserRouter>
+        <ScrollToTop />
             <Routes>
                 <Route path="/" element={<Home />} />
                 <Route path="/about" element={<AboutUs />} />

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -2,6 +2,12 @@ import ReactDOM from "react-dom/client";
 import { ChakraProvider } from "@chakra-ui/react";
 import App from "./App";
 
+if (typeof window !== "undefined" && "scrollRestoration" in window.history) {
+  window.history.scrollRestoration = "manual";
+}
+
+window.scrollTo(0, 0);
+
 ReactDOM.createRoot(document.getElementById("root")).render(
   <ChakraProvider>
     <App />


### PR DESCRIPTION
Wrapped routes in function that scrolls to base of that route using React Hook.
Changed scroll restoration to manual to enforce pages go to top when navigating different tabs instead of the browser saving the place.