### PR TITLE
Resized specific programs to be wider on all screens

### DIFF
--- a/client/src/components/allPrograms/program/MeasurableProgress.jsx
+++ b/client/src/components/allPrograms/program/MeasurableProgress.jsx
@@ -72,7 +72,7 @@ export default function MeasurableProgress({ id }) {
       <Box as="section" bg="brand.navy" width="100%" py={{ base: 12, md: 16, lg: 20 }}>
         <Box maxW="1200px" mx="auto" px={{ base: 4, md: 10, lg: 20 }}>
           <Box bg="surface.glass" borderRadius="2xl" p={{ base: 6, md: 8 }}>
-            <Heading fontSize={{ base: "4xl", md: "5xl" }} color="surface.default" mb={4}>
+            <Heading fontSize={{ base: "3xl", md: "5xl" }} color="surface.default" mb={4}>
               Measurable Progress
             </Heading>
             <Text color="gray.200">{errorMsg}</Text>
@@ -84,7 +84,7 @@ export default function MeasurableProgress({ id }) {
 
   return (
     <Box as="section" bg="brand.navy" width="100%" py={{ base: 12, md: 16, lg: 20 }} borderRadius="3xl" overflow="hidden">
-      <Box maxW="2500px" mx="auto" px={{ base: 24, md: 52, lg: 80 }}>
+      <Box maxW="2500px" mx="auto" px={{ base: "14", sm: 24, md: 52, lg: 80 }}>
         <Box bg="brand.navy" borderRadius="3xl" px={{ base: 4, md: 6, lg: 8 }} py={{ base: 8, md: 10, lg: 12 }}>
           <FadeInWhenVisible
             w="100%"
@@ -96,7 +96,7 @@ export default function MeasurableProgress({ id }) {
           >
             <Heading
               as="h2"
-              fontSize={{ base: "4xl", md: "6xl", lg: "7xl" }}
+              fontSize={{ base: "2xl", small: "4xl", md: "6xl", lg: "7xl" }}
               lineHeight={1.02}
               color="surface.default"
               fontWeight="800"

--- a/client/src/components/allPrograms/program/MeasurableProgress.jsx
+++ b/client/src/components/allPrograms/program/MeasurableProgress.jsx
@@ -84,7 +84,7 @@ export default function MeasurableProgress({ id }) {
 
   return (
     <Box as="section" bg="brand.navy" width="100%" py={{ base: 12, md: 16, lg: 20 }} borderRadius="3xl" overflow="hidden">
-      <Box maxW="2500px" mx="auto" px={{ base: "14", sm: 24, md: 52, lg: 80 }}>
+      <Box maxW="2500px" mx="auto" px={{ base: 14, sm: 24, md: 52, lg: 80 }}>
         <Box bg="brand.navy" borderRadius="3xl" px={{ base: 4, md: 6, lg: 8 }} py={{ base: 8, md: 10, lg: 12 }}>
           <FadeInWhenVisible
             w="100%"
@@ -96,7 +96,7 @@ export default function MeasurableProgress({ id }) {
           >
             <Heading
               as="h2"
-              fontSize={{ base: "2xl", small: "4xl", md: "6xl", lg: "7xl" }}
+              fontSize={{ base: "4xl", sm: "4xl", md: "6xl", lg: "7xl" }}
               lineHeight={1.02}
               color="surface.default"
               fontWeight="800"

--- a/client/src/components/allPrograms/program/ProgramHeader.jsx
+++ b/client/src/components/allPrograms/program/ProgramHeader.jsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Text, Link } from "@chakra-ui/react";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { NavLink } from "react-router-dom";
 import FadeInWhenVisible from "../../home/ui/FadeInWhenVisible";
 import { useProgramById } from "../../../hooks/useProgramsById";
@@ -27,12 +27,12 @@ const breadcrumbLinkProps = {
 
 export default function ProgramHeader({ id, backgroundPosition }) {
   const { program } = useProgramById(id);
-  const [ isImgLoaded, setIsImgLoaded ] = useEffect(false);
+  const [ isImgLoaded, setIsImgLoaded ] = useState(false);
 
   const backgroundImageSrc = resolveProgramImage(program?.background_image);
   const programTitle = String(program?.title ?? "").trim() || "Loading program...";
 
-  useEffect (() => {
+  useState (() => {
     if (!backgroundImageSrc) return;
 
     setIsImgLoaded(false);

--- a/client/src/components/allPrograms/program/ProgramHeader.jsx
+++ b/client/src/components/allPrograms/program/ProgramHeader.jsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Text, Link } from "@chakra-ui/react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { NavLink } from "react-router-dom";
 import FadeInWhenVisible from "../../home/ui/FadeInWhenVisible";
 import { useProgramById } from "../../../hooks/useProgramsById";

--- a/client/src/components/allPrograms/program/ProgramHeader.jsx
+++ b/client/src/components/allPrograms/program/ProgramHeader.jsx
@@ -128,7 +128,7 @@ export default function ProgramHeader({ id, backgroundPosition }) {
 
           <Text
               fontFamily="Inter"
-              fontSize= {{base: "32px", sm  : "40px", md : "54px", lg:"64px"}}
+              fontSize= {{base: "45px", md: "54px", lg:"64px"}}
               fontStyle="normal"
               fontWeight="800"
               lineHeight="100%"

--- a/client/src/components/allPrograms/program/ProgramHeader.jsx
+++ b/client/src/components/allPrograms/program/ProgramHeader.jsx
@@ -128,7 +128,7 @@ export default function ProgramHeader({ id, backgroundPosition }) {
 
           <Text
               fontFamily="Inter"
-              fontSize="64px"
+              fontSize= {{base: "32px", sm  : "40px", md : "54px", lg:"64px"}}
               fontStyle="normal"
               fontWeight="800"
               lineHeight="100%"

--- a/client/src/components/allPrograms/program/ProgramPage.jsx
+++ b/client/src/components/allPrograms/program/ProgramPage.jsx
@@ -11,7 +11,7 @@ export default function ProgramPage({ id, backgroundPosition }) {
         position="absolute"
         left="-167px"
         top="25%"
-        width= {{base: "334px", md: "725px"}}
+        width="334px"
         height="334px"
         borderRadius="334px"
         border="40px solid"

--- a/client/src/components/allPrograms/program/ProgramPage.jsx
+++ b/client/src/components/allPrograms/program/ProgramPage.jsx
@@ -11,7 +11,7 @@ export default function ProgramPage({ id, backgroundPosition }) {
         position="absolute"
         left="-167px"
         top="25%"
-        width="334px"
+        width= {{base: "334px", md: "725px"}}
         height="334px"
         borderRadius="334px"
         border="40px solid"

--- a/client/src/components/allPrograms/program/ProgramProblemSolution.jsx
+++ b/client/src/components/allPrograms/program/ProgramProblemSolution.jsx
@@ -108,7 +108,7 @@ export default function ProgramProblemSolution({ id }) {
           <FadeInWhenVisible w="100%" amount={0.4}>
           <Heading
             as="h2"
-            fontSize={{ base: "2xl", md: "5xl", lg: "6xl" }}
+            fontSize={{ sm: "2xl", md: "5xl", lg: "6xl" }}
             lineHeight={{ base: 1.2, md: 1.25 }}
           >
             {parseBold(program?.summary)}
@@ -122,11 +122,11 @@ export default function ProgramProblemSolution({ id }) {
             gap={{ base: 8, md: 10, lg: 14 }}
           >
             <Box flex="1.2">
-              <Heading as="h3" fontSize={{ base: "2xl", md: "5xl", lg: "6xl" }} mb={5} color="brand.heading">
+              <Heading as="h3" fontSize={{ sm: "2xl", md: "5xl", lg: "6xl" }} mb={5} color="brand.heading">
                 The Problem
               </Heading>
               <Text
-                fontSize={{ base: "lg", md: "3xl", lg: "4xl" }}
+                fontSize={{ sm: "lg", md: "3xl", lg: "4xl" }}
                 lineHeight={1.5}
                 whiteSpace="pre-line"
               >
@@ -185,14 +185,14 @@ export default function ProgramProblemSolution({ id }) {
             </Box>
 
             <Box flex="1.2">
-              <Heading as="h3" fontSize={{ base: "2xl", md: "5xl", lg: "6xl" }} mb={5} color="brand.heading">
+              <Heading as="h3" fontSize={{ sm: "2xl", md: "5xl", lg: "6xl" }} mb={5} color="brand.heading">
                 What We're Doing
               </Heading>
 
               {paragraphs.map((paragraph, idx) => (
                 <Text
                   key={`solution-paragraph-${idx}`}
-                  fontSize={{ base: "lg", md: "3xl", lg: "4xl" }}
+                  fontSize={{ sm: "lg", md: "3xl", lg: "4xl" }}
                   lineHeight={1.5}
                   mb={bullets.length > 0 || idx < paragraphs.length - 1 ? 4 : 0}
                 >
@@ -205,7 +205,7 @@ export default function ProgramProblemSolution({ id }) {
                   {bullets.map((bullet, idx) => (
                     <ListItem
                       key={`solution-bullet-${idx}`}
-                      fontSize={{ base: "lg", md: "3xl", lg: "4xl" }}
+                      fontSize={{ sm: "lg", md: "3xl", lg: "4xl" }}
                     >
                       {parseBold(bullet)}
                     </ListItem>

--- a/client/src/components/allPrograms/program/ProgramProblemSolution.jsx
+++ b/client/src/components/allPrograms/program/ProgramProblemSolution.jsx
@@ -101,10 +101,9 @@ export default function ProgramProblemSolution({ id }) {
       width="100%"
       py={{ base: 12, md: 16, lg: 20 }}
     >
-      <Box maxW="2500px" mx="auto" px={{ base: 24, md: 52, lg: 80 }}>
+      <Box maxW="2500px" mx="auto" px={{ base: 24, md: 26, lg: 32  }}>
         <VStack
           spacing={{ base: 12, md: 16, lg: 20 }}
-          align="stretch"
         >
           <FadeInWhenVisible w="100%" amount={0.4}>
           <Heading

--- a/client/src/components/allPrograms/program/ProgramProblemSolution.jsx
+++ b/client/src/components/allPrograms/program/ProgramProblemSolution.jsx
@@ -101,7 +101,7 @@ export default function ProgramProblemSolution({ id }) {
       width="100%"
       py={{ base: 12, md: 16, lg: 20 }}
     >
-      <Box maxW="2500px" mx="auto" px={{ base: 24, md: 26, lg: 32  }}>
+      <Box maxW="2500px" mx="auto" px={{ base: 8, md: 20, lg: 32  }}>
         <VStack
           spacing={{ base: 12, md: 16, lg: 20 }}
         >

--- a/client/src/components/allPrograms/program/ProgramProblemSolution.jsx
+++ b/client/src/components/allPrograms/program/ProgramProblemSolution.jsx
@@ -108,7 +108,7 @@ export default function ProgramProblemSolution({ id }) {
           <FadeInWhenVisible w="100%" amount={0.4}>
           <Heading
             as="h2"
-            fontSize={{base: "2xl", sm: "3xl", md: "5xl", lg: "6xl" }}
+            fontSize={{base: "4xl", sm: "4xl", md: "5xl", lg: "6xl" }}
             lineHeight={{ base: 1.2, md: 1.25 }}
           >
             {parseBold(program?.summary)}

--- a/client/src/components/allPrograms/program/ProgramProblemSolution.jsx
+++ b/client/src/components/allPrograms/program/ProgramProblemSolution.jsx
@@ -108,7 +108,7 @@ export default function ProgramProblemSolution({ id }) {
           <FadeInWhenVisible w="100%" amount={0.4}>
           <Heading
             as="h2"
-            fontSize={{ base: "4xl", md: "5xl", lg: "6xl" }}
+            fontSize={{ base: "2xl", md: "5xl", lg: "6xl" }}
             lineHeight={{ base: 1.2, md: 1.25 }}
           >
             {parseBold(program?.summary)}
@@ -122,11 +122,11 @@ export default function ProgramProblemSolution({ id }) {
             gap={{ base: 8, md: 10, lg: 14 }}
           >
             <Box flex="1.2">
-              <Heading as="h3" fontSize={{ base: "4xl", md: "5xl", lg: "6xl" }} mb={5} color="brand.heading">
+              <Heading as="h3" fontSize={{ base: "2xl", md: "5xl", lg: "6xl" }} mb={5} color="brand.heading">
                 The Problem
               </Heading>
               <Text
-                fontSize={{ base: "2xl", md: "3xl", lg: "4xl" }}
+                fontSize={{ base: "lg", md: "3xl", lg: "4xl" }}
                 lineHeight={1.5}
                 whiteSpace="pre-line"
               >
@@ -185,14 +185,14 @@ export default function ProgramProblemSolution({ id }) {
             </Box>
 
             <Box flex="1.2">
-              <Heading as="h3" fontSize={{ base: "4xl", md: "5xl", lg: "6xl" }} mb={5} color="brand.heading">
+              <Heading as="h3" fontSize={{ base: "2xl", md: "5xl", lg: "6xl" }} mb={5} color="brand.heading">
                 What We're Doing
               </Heading>
 
               {paragraphs.map((paragraph, idx) => (
                 <Text
                   key={`solution-paragraph-${idx}`}
-                  fontSize={{ base: "2xl", md: "3xl", lg: "4xl" }}
+                  fontSize={{ base: "lg", md: "3xl", lg: "4xl" }}
                   lineHeight={1.5}
                   mb={bullets.length > 0 || idx < paragraphs.length - 1 ? 4 : 0}
                 >
@@ -205,7 +205,7 @@ export default function ProgramProblemSolution({ id }) {
                   {bullets.map((bullet, idx) => (
                     <ListItem
                       key={`solution-bullet-${idx}`}
-                      fontSize={{ base: "2xl", md: "3xl", lg: "4xl" }}
+                      fontSize={{ base: "lg", md: "3xl", lg: "4xl" }}
                     >
                       {parseBold(bullet)}
                     </ListItem>

--- a/client/src/components/allPrograms/program/ProgramProblemSolution.jsx
+++ b/client/src/components/allPrograms/program/ProgramProblemSolution.jsx
@@ -101,14 +101,14 @@ export default function ProgramProblemSolution({ id }) {
       width="100%"
       py={{ base: 12, md: 16, lg: 20 }}
     >
-      <Box maxW="2500px" mx="auto" px={{ sm: 2, md: 12, lg: 32  }}>
+      <Box maxW="2500px" mx="auto" px={{ sm: 12, md: 22, lg: 32  }}>
         <VStack
           spacing={{ base: 12, md: 16, lg: 20 }}
         >
           <FadeInWhenVisible w="100%" amount={0.4}>
           <Heading
             as="h2"
-            fontSize={{ sm: "2xl", md: "5xl", lg: "6xl" }}
+            fontSize={{ sm: "3xl", md: "5xl", lg: "6xl" }}
             lineHeight={{ base: 1.2, md: 1.25 }}
           >
             {parseBold(program?.summary)}
@@ -122,11 +122,11 @@ export default function ProgramProblemSolution({ id }) {
             gap={{ base: 8, md: 10, lg: 14 }}
           >
             <Box flex="1.2">
-              <Heading as="h3" fontSize={{ sm: "2xl", md: "5xl", lg: "6xl" }} mb={5} color="brand.heading">
+              <Heading as="h3" fontSize={{ sm: "3xl", md: "5xl", lg: "6xl" }} mb={5} color="brand.heading">
                 The Problem
               </Heading>
               <Text
-                fontSize={{ sm: "lg", md: "3xl", lg: "4xl" }}
+                fontSize={{ sm: "2xl", md: "3xl", lg: "4xl" }}
                 lineHeight={1.5}
                 whiteSpace="pre-line"
               >
@@ -185,14 +185,14 @@ export default function ProgramProblemSolution({ id }) {
             </Box>
 
             <Box flex="1.2">
-              <Heading as="h3" fontSize={{ sm: "2xl", md: "5xl", lg: "6xl" }} mb={5} color="brand.heading">
+              <Heading as="h3" fontSize={{ sm: "3xl", md: "5xl", lg: "6xl" }} mb={5} color="brand.heading">
                 What We're Doing
               </Heading>
 
               {paragraphs.map((paragraph, idx) => (
                 <Text
                   key={`solution-paragraph-${idx}`}
-                  fontSize={{ sm: "lg", md: "3xl", lg: "4xl" }}
+                  fontSize={{ sm: "2xl", md: "3xl", lg: "4xl" }}
                   lineHeight={1.5}
                   mb={bullets.length > 0 || idx < paragraphs.length - 1 ? 4 : 0}
                 >
@@ -205,7 +205,7 @@ export default function ProgramProblemSolution({ id }) {
                   {bullets.map((bullet, idx) => (
                     <ListItem
                       key={`solution-bullet-${idx}`}
-                      fontSize={{ sm: "lg", md: "3xl", lg: "4xl" }}
+                      fontSize={{ sm: "2xl", md: "3xl", lg: "4xl" }}
                     >
                       {parseBold(bullet)}
                     </ListItem>

--- a/client/src/components/allPrograms/program/ProgramProblemSolution.jsx
+++ b/client/src/components/allPrograms/program/ProgramProblemSolution.jsx
@@ -101,7 +101,7 @@ export default function ProgramProblemSolution({ id }) {
       width="100%"
       py={{ base: 12, md: 16, lg: 20 }}
     >
-      <Box maxW="2500px" mx="auto" px={{ base: 8, md: 20, lg: 32  }}>
+      <Box maxW="2500px" mx="auto" px={{ sm: 2, md: 12, lg: 32  }}>
         <VStack
           spacing={{ base: 12, md: 16, lg: 20 }}
         >

--- a/client/src/components/allPrograms/program/ProgramProblemSolution.jsx
+++ b/client/src/components/allPrograms/program/ProgramProblemSolution.jsx
@@ -101,14 +101,14 @@ export default function ProgramProblemSolution({ id }) {
       width="100%"
       py={{ base: 12, md: 16, lg: 20 }}
     >
-      <Box maxW="2500px" mx="auto" px={{ sm: 12, md: 22, lg: 32  }}>
+      <Box maxW="2500px" mx="auto" px={{base: 8, sm: 12, md: 22, lg: 32  }}>
         <VStack
           spacing={{ base: 12, md: 16, lg: 20 }}
         >
           <FadeInWhenVisible w="100%" amount={0.4}>
           <Heading
             as="h2"
-            fontSize={{ sm: "3xl", md: "5xl", lg: "6xl" }}
+            fontSize={{base: "2xl", sm: "3xl", md: "5xl", lg: "6xl" }}
             lineHeight={{ base: 1.2, md: 1.25 }}
           >
             {parseBold(program?.summary)}
@@ -122,11 +122,11 @@ export default function ProgramProblemSolution({ id }) {
             gap={{ base: 8, md: 10, lg: 14 }}
           >
             <Box flex="1.2">
-              <Heading as="h3" fontSize={{ sm: "3xl", md: "5xl", lg: "6xl" }} mb={5} color="brand.heading">
+              <Heading as="h3" fontSize={{ base: "2xl", sm: "3xl", md: "5xl", lg: "6xl" }} mb={5} color="brand.heading">
                 The Problem
               </Heading>
               <Text
-                fontSize={{ sm: "2xl", md: "3xl", lg: "4xl" }}
+                fontSize={{base: "xl", sm: "2xl", md: "3xl", lg: "4xl" }}
                 lineHeight={1.5}
                 whiteSpace="pre-line"
               >
@@ -185,14 +185,14 @@ export default function ProgramProblemSolution({ id }) {
             </Box>
 
             <Box flex="1.2">
-              <Heading as="h3" fontSize={{ sm: "3xl", md: "5xl", lg: "6xl" }} mb={5} color="brand.heading">
+              <Heading as="h3" fontSize={{ base: "2xl", sm: "3xl", md: "5xl", lg: "6xl" }} mb={5} color="brand.heading">
                 What We're Doing
               </Heading>
 
               {paragraphs.map((paragraph, idx) => (
                 <Text
                   key={`solution-paragraph-${idx}`}
-                  fontSize={{ sm: "2xl", md: "3xl", lg: "4xl" }}
+                  fontSize={{base: "xl", sm: "2xl", md: "3xl", lg: "4xl" }}
                   lineHeight={1.5}
                   mb={bullets.length > 0 || idx < paragraphs.length - 1 ? 4 : 0}
                 >
@@ -205,7 +205,7 @@ export default function ProgramProblemSolution({ id }) {
                   {bullets.map((bullet, idx) => (
                     <ListItem
                       key={`solution-bullet-${idx}`}
-                      fontSize={{ sm: "2xl", md: "3xl", lg: "4xl" }}
+                      fontSize={{base: "xl", sm: "2xl", md: "3xl", lg: "4xl" }}
                     >
                       {parseBold(bullet)}
                     </ListItem>


### PR DESCRIPTION
Resized specific programs to have more visual spacing. Primarily changed padding x, but also changed font sizes for different screen sizes.

Before examples:
First Image is on desktop on normal aspect ratio, second is mobile
<img width="2175" height="1231" alt="image" src="https://github.com/user-attachments/assets/44620b09-a9be-4f68-bd0b-12d08ed97d3c" />
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/96623d54-3165-4ad9-a900-d2137008f4a9" />


After examples:
First Image is on desktop on normal aspect ratio, others are mobile
<img width="2171" height="1228" alt="image" src="https://github.com/user-attachments/assets/521f9367-60a4-4202-ad9a-c8d04513ef21" />

<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/9c05e7e7-0953-4ad1-8968-af41743c9534" />

<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/635dd35b-7b6a-46b9-8cc3-885f6c2f19ce" />
